### PR TITLE
refactor: simplify EVM→TON receiver address encoding

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,25 +23,14 @@ Understanding these details is crucial because EVM (Ethereum Virtual Machine) an
 *Script:* `evm2ton/sendMessage.ts`
 
 ### Address Encoding (EVM → TON)
-**The Challenge:** The EVM Router expects a `bytes` receiver address. However, you cannot just send a string like `"EQB..."`. The TON OffRamp contract needs the raw components to reconstruct the address.
+**The Challenge:** The EVM Router expects a `bytes` receiver address, but a TON address is typically a user-friendly base64-encoded string (e.g., `"EQB..."`).
 
-**The Solution:** We encode the TON address into a standardized **36-byte** format.
+**The Solution:** TON user-friendly addresses are base64-encoded 36-byte sequences. Decode the address string directly:
 
 ```typescript
-// 1. Parse Friendly Address
-const tonAddr = Address.parse("EQB..."); 
-
-// 2. Extract Components
-const workchain = tonAddr.workChain; // 0 or -1
-const hash = tonAddr.hash;           // 32-byte unique ID
-
-// 3. Pack into 36 Bytes (Big-Endian)
-// [ 4 bytes workchain (int32) ] + [ 32 bytes hash ]
-const workchainBytes = new Uint8Array(4)
-new DataView(workchainBytes.buffer).setInt32(0, workchain, false) // big-endian
-const receiverBytes = ethers.concat([workchainBytes, hash])
-// e.g. workchain 0  → 0x00000000 + 32-byte hash
-// e.g. workchain -1 → 0xffffffff + 32-byte hash
+const tonContractAddr = "EQB9QIw22sgwNKMfqsMKGepkhnjXYJmXlzCgcBSAlaiF9VCj"
+const receiverBytes = new Uint8Array(Buffer.from(tonContractAddr, 'base64'))
+// 36 bytes: [ 1 byte flags ] + [ 1 byte workchain ] + [ 32 bytes hash ] + [ 2 bytes CRC16 ]
 ```
 
 ### ExtraArgs & Execution Parameters
@@ -137,9 +126,10 @@ const extraArgs = beginCell()
 ## Byte-Level Encoding Details
 
 ### 1. The 36-Byte Address (EVM → TON)
-The workchain is encoded as a signed 32-bit big-endian integer:
-*   Workchain `0`  → `0x00000000` + 32-byte hash
-*   Workchain `-1` → `0xffffffff` + 32-byte hash
+TON user-friendly addresses (e.g., `EQ...`, `UQ...`) are base64-encoded 36-byte sequences:
+`[ 1 byte flags ] + [ 1 byte workchain ] + [ 32 bytes hash ] + [ 2 bytes CRC16 ]`
+
+`Buffer.from(tonAddr, 'base64')` decodes this directly. The EVM CCIP Router and TON OffRamp both accept this user-friendly byte format.
 
 ### 2. The ExtraArgs Bitmask (TON → EVM)
 If you send `gasLimit: 100_000`, the binary stream looks like this:
@@ -160,7 +150,7 @@ The parser interprets the first bit of `100000` (which is `0`) as the presence f
 
 | Feature | EVM → TON | TON → EVM |
 | :--- | :--- | :--- |
-| **Address Format** | 36 Bytes (4B workchain int32 + 32B hash) | 32 Bytes zero-padded (12B zeros + 20B address), length-prefixed by `CrossChainAddress` |
+| **Address Format** | 36 Bytes (base64-decoded user-friendly: 1B flags + 1B workchain + 32B hash + 2B CRC) | 32 Bytes zero-padded (12B zeros + 20B address), length-prefixed by `CrossChainAddress` |
 | **Ordering** | `allowOutOfOrder = true` (Mandatory) | `allowOutOfOrder = true` (Recommended) |
 | **ExtraArgs Fmt** | ABI Encoded (`bytes`) | TL-B Encoded (`Cell`) |
 | **gasLimit units** | nanoTON (e.g. `100_000_000n` = 0.1 TON) | EVM gas units (e.g. `100_000`) |

--- a/scripts/evm2ton/sendMessage.ts
+++ b/scripts/evm2ton/sendMessage.ts
@@ -4,7 +4,7 @@ import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import { supportedEvmChains, networkConfig, ccipExplorerUrl } from '../../helper-config'
 import IRouterClientArtifact from '../../artifacts/@chainlink/contracts-ccip/contracts/interfaces/IRouterClient.sol/IRouterClient.json'
-import { encodeTONAddress, buildCCIPMessageForTON, extractCCIPMessageIdForTON, getCCIPFeeForTON, getEvmChainConfig, getRpcUrlForEvmChain } from '../utils/utils'
+import { buildCCIPMessageForTON, extractCCIPMessageIdForTON, getCCIPFeeForTON, getEvmChainConfig, getRpcUrlForEvmChain } from '../utils/utils'
 import { getTonExplorerLinks } from '../ton-utils/addressFormats'
 
 const erc20Abi = [
@@ -85,7 +85,7 @@ async function sendEVMToTON() {
   const tonReceiverAddr = argv.tonReceiver
   const tonAddr = Address.parse(tonReceiverAddr)
   const tonReceiverExplorerLinks = getTonExplorerLinks(networkConfig.tonTestnet.explorer, tonAddr)
-  const receiverBytes = encodeTONAddress(tonAddr)
+  const receiverBytes = new Uint8Array(Buffer.from(tonReceiverAddr, 'base64'))
   const messageData = ethers.toUtf8Bytes(argv.msg)
   const router = new ethers.Contract(sourceChain.router, IRouterClientArtifact.abi, wallet)
   const destChainSelector = BigInt(networkConfig.tonTestnet.chainSelector)

--- a/scripts/utils/utils.ts
+++ b/scripts/utils/utils.ts
@@ -10,18 +10,7 @@ const GENERIC_EXTRA_ARGS_V2_TAG = '0x181dcf10'
 const CCIP_SEND_OPCODE = 0x31768d95
 
 /**
- * [EVM → TON] Encodes a TON address into the 36-byte format expected by the EVM CCIP Router.
- * Format: 4-byte workchain (int32, big-endian) + 32-byte address hash.
- * Source: chainlink-ton/pkg/ccip/codec/addresscodec.go
- */
-export function encodeTONAddress(addr: Address): Uint8Array {
-  const workchainBytes = new Uint8Array(4)
-  new DataView(workchainBytes.buffer).setInt32(0, addr.workChain, false)
-  return ethers.getBytes(ethers.concat([workchainBytes, addr.hash]))
-}
-
-/**
- * [TON → EVM] Encodes an EVM address into the 44-byte format expected by the TON CCIP Router.
+ * [TON → EVM] Encodes an EVM address into the 32-byte format expected by the TON CCIP Router.
  * Format: 12 zero-bytes (left-pad) + 20-byte EVM address.
  */
 export function encodeEVMAddress(evmAddr: string): Buffer {


### PR DESCRIPTION
Removes the `encodeTONAddress` helper and replaces it with a direct `Buffer.from(addr, 'base64')` inline conversion in `sendMessage.ts`. TON user-friendly addresses are base64-encoded 36-byte sequences, so decoding the string directly produces the bytes the EVM CCIP Router expects — no manual workchain/hash assembly needed.

### Changes

- `scripts/utils/utils.ts` — removed `encodeTONAddress` function (dead code, no remaining call sites)
- `scripts/evm2ton/sendMessage.ts` — inline-decoded receiver address; removed now-unused import
- `scripts/README.md` — updated EVM→TON address encoding section and Quick Reference table to reflect the simpler approach