### PR TITLE
refactor: rename native coin references from TON to GRAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This starter kit includes three receiver contracts for EVM → TON messaging:
 
 The three mandatory steps every TON CCIP receiver must implement:
 1. Accept `CCIPReceive` messages **only from the authorized CCIP Router**
-2. Verify the attached value (gas limit) is **sufficient** — the Router needs at least 0.02 TON to process the confirmation, so `MIN_VALUE` should be set above that and account for your own execution costs
+2. Verify the attached value (gas limit) is **sufficient** — the Router needs at least 0.02 GRAM to process the confirmation, so `MIN_VALUE` should be set above that and account for your own execution costs
 3. Send `Router_CCIPReceiveConfirm` back to the Router so the protocol marks the message as delivered
 
 > **Note:** `receiver_with_validateAndConfirm.tolk` uses the Receiver library helper which is still in early development. For complex receivers, prefer `minimal_receiver.tolk` and implement the steps inline.

--- a/contracts/minimal_receiver.tolk
+++ b/contracts/minimal_receiver.tolk
@@ -5,7 +5,7 @@
 //
 //   1. Accept CCIPReceive messages ONLY from the authorized CCIP Router.
 //   2. Verify the attached value (gas limit) is sufficient.
-//      The Router needs at least 0.02 TON to process the confirmation message,
+//      The Router needs at least 0.02 GRAM to process the confirmation message,
 //      so MIN_VALUE should be set above that and account for your own execution costs.
 //   3. Send Router_CCIPReceiveConfirm back to the Router so the protocol can mark
 //      the message as successfully delivered.
@@ -42,8 +42,8 @@ fun Storage.store(self) {
 
 /// Minimum value (gas limit) the sender must attach to a CCIPReceive message.
 ///
-/// The Router needs at least 0.02 TON to forward the confirmation back through the
-/// protocol chain. Use 0.03 TON as a baseline and increase it to cover your own
+/// The Router needs at least 0.02 GRAM to forward the confirmation back through the
+/// protocol chain. Use 0.03 GRAM as a baseline and increase it to cover your own
 /// execution costs. Benchmark your contract logic and set this accordingly.
 const MIN_VALUE: coins = ton("0.03");
 
@@ -74,12 +74,12 @@ fun onInternalMessage(in: InMessage) {
             assert(in.senderAddress == st.router) throw (Receiver_Error.Unauthorized as int);
 
             // 2. Verify enough value is attached to cover gas costs.
-            //    The Router needs at least 0.02 TON for the confirmation message.
+            //    The Router needs at least 0.02 GRAM for the confirmation message.
             //    Increase MIN_VALUE to account for your contract's execution costs.
             assert(in.valueCoins >= MIN_VALUE) throw (Receiver_Error.LowValue as int);
 
             // 3. Send CCIPReceiveConfirm back to the Router.
-            //    SEND_MODE_CARRY_ALL_REMAINING_MESSAGE_VALUE forwards all remaining TON
+            //    SEND_MODE_CARRY_ALL_REMAINING_MESSAGE_VALUE forwards all remaining GRAM
             //    (gas limit minus fees so far) to pay for the confirmation transaction.
             val receiveConfirm = createMessage({
                 bounce: true,
@@ -97,7 +97,7 @@ fun onInternalMessage(in: InMessage) {
             // ★ YOUR LOGIC ENDS HERE
         }
         else => {
-            // Ignore plain TON transfers; reject unknown opcodes.
+            // Ignore plain GRAM transfers; reject unknown opcodes.
             assert(in.body.isEmpty()) throw 0xFFFF;
         }
     }

--- a/contracts/minimal_sender.tolk
+++ b/contracts/minimal_sender.tolk
@@ -7,7 +7,7 @@
 //
 // The contract:
 //   1. Receives a RelayCCIPSend message containing the pre-built CCIPSend message
-//      and the TON value to forward to the Router.
+//      and the GRAM value to forward to the Router.
 //   2. Forwards the Router_CCIPSend to the CCIP Router with the specified value.
 //   3. Handles Router ACK/NACK responses — replace the handlers with your product logic.
 //
@@ -21,11 +21,11 @@ import "../chainlink-ton/contracts/contracts/ccip/router/messages"  // Router_CC
 /// Sent to this contract to trigger a CCIP send.
 ///
 /// routerAddress: the CCIP Router to forward the message to.
-/// valueToAttach: the TON amount to attach when forwarding to the Router.
+/// valueToAttach: the GRAM amount to attach when forwarding to the Router.
 ///               Must cover the CCIP fee — query getCCIPFee off-chain before sending.
 ///               The total value sent to this contract must be valueToAttach plus
-///               enough extra to cover this contract's own execution costs (~0.1 TON).
-///               Any TON surplus above compute costs is returned via ACK (message accepted)
+///               enough extra to cover this contract's own execution costs (~0.1 GRAM).
+///               Any GRAM surplus above compute costs is returned via ACK (message accepted)
 ///               or NACK (message rejected — both fee and surplus are returned).
 /// message: the pre-built Router_CCIPSend message cell.
 struct (0x00000001) CCIPSender_RelayCCIPSend {
@@ -50,19 +50,19 @@ fun onInternalMessage(in: InMessage) {
         Router_CCIPSendACK => {
             // ★ CCIP message was accepted by the Router.
             //   msg.messageId contains the unique CCIP message ID.
-            //   Any TON surplus above compute costs is returned here; the fee is not refunded.
+            //   Any GRAM surplus above compute costs is returned here; the fee is not refunded.
             //   Add your on-chain success handling here (e.g. update state, emit event).
             return;
         }
         Router_CCIPSendNACK => {
             // ★ CCIP send was rejected by the Router.
-            //   Both the fee and any TON surplus are returned here since the message was not accepted.
+            //   Both the fee and any GRAM surplus are returned here since the message was not accepted.
             //   msg.error contains the Router exit code indicating the rejection reason.
             //   Add your on-chain failure handling here (e.g. refund, retry logic).
             throw msg.error;
         }
         else => {
-            // Ignore plain TON transfers; reject unknown opcodes.
+            // Ignore plain GRAM transfers; reject unknown opcodes.
             assert(in.body.isEmpty()) throw 0xFFFF;
         }
     }

--- a/contracts/receiver_with_validateAndConfirm.tolk
+++ b/contracts/receiver_with_validateAndConfirm.tolk
@@ -16,8 +16,8 @@
 //
 // IMPORTANT: The Receiver library is still in early development. Always
 // benchmark your contract and set MIN_VALUE to cover your actual execution
-// costs. The Router needs at least 0.02 TON to process the confirmation
-// message — use 0.03 TON as a safe baseline and increase from there.
+// costs. The Router needs at least 0.02 GRAM to process the confirmation
+// message — use 0.03 GRAM as a safe baseline and increase from there.
 
 import "../chainlink-ton/contracts/contracts/lib/utils"             // emit
 import "../chainlink-ton/contracts/contracts/lib/receiver/types"    // Any2TVMMessage
@@ -42,8 +42,8 @@ fun Storage.store(self) {
 
 /// Minimum value (gas limit) the sender must attach to a CCIPReceive message.
 ///
-/// The Router needs at least 0.02 TON to forward the confirmation back through the
-/// protocol chain. Use 0.03 TON as a baseline and increase it to cover your own
+/// The Router needs at least 0.02 GRAM to forward the confirmation back through the
+/// protocol chain. Use 0.03 GRAM as a baseline and increase it to cover your own
 /// execution costs. Benchmark your contract logic and set this accordingly.
 const MIN_VALUE: coins = ton("0.03");
 
@@ -69,7 +69,7 @@ fun onInternalMessage(in: InMessage) {
             //   1. Verifies the sender is the authorized CCIP Router.
             //   2. Verifies the attached value meets MIN_VALUE.
             //   3. Sends CCIPReceiveConfirm back to the Router, forwarding
-            //      all remaining TON via SEND_MODE_CARRY_ALL_REMAINING_MESSAGE_VALUE.
+            //      all remaining GRAM via SEND_MODE_CARRY_ALL_REMAINING_MESSAGE_VALUE.
             msg.validateAndConfirm({
                 router: st.router,
                 minValue: MIN_VALUE,
@@ -87,7 +87,7 @@ fun onInternalMessage(in: InMessage) {
             // ★ YOUR LOGIC ENDS HERE
         }
         else => {
-            // Ignore plain TON transfers; reject unknown opcodes.
+            // Ignore plain GRAM transfers; reject unknown opcodes.
             assert(in.body.isEmpty()) throw 0xFFFF;
         }
     }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,7 +45,7 @@ const receiverBytes = new Uint8Array(Buffer.from(tonContractAddr, 'base64'))
 const extraArgs = abiCoder.encode(
   ['uint256', 'bool'],
   [
-    100_000_000, // gasLimit in nanoTON (0.1 TON = 100,000,000 nanoTON)
+    100_000_000, // gasLimit in nanoGRAM (0.1 GRAM = 100,000,000 nanoGRAM)
     true     // allowOutOfOrderExecution: MUST BE TRUE for TON
   ]
 );
@@ -53,7 +53,7 @@ const extraArgs = abiCoder.encode(
 const finalArgs = ethers.concat(['0x181dcf10', extraArgs]);
 ```
 
-**Important:** For EVM → TON, the `gasLimit` represents the amount of **TON (in nanoTON)** allocated for executing the message on TON. This is different from EVM gas semantics. The scripts use `100_000_000n` (0.1 TON) as the default.
+**Important:** For EVM → TON, the `gasLimit` represents the amount of **GRAM (in nanoGRAM)** allocated for executing the message on TON. This is different from EVM gas semantics. The scripts use `100_000_000n` (0.1 GRAM) as the default.
 
 ### Data Payload (EVM → TON)
 *   **Input:** `bytes` (EVM side)
@@ -108,7 +108,7 @@ const extraArgs = beginCell()
   .endCell();
 ```
 
-**Important:** For TON → EVM, the `gasLimit` is in **EVM gas units** (not nanoTON). The scripts use `100_000` EVM gas units as the default.
+**Important:** For TON → EVM, the `gasLimit` is in **EVM gas units** (not nanoGRAM). The scripts use `100_000` EVM gas units as the default.
 
 ### Data Payload (TON → EVM)
 *   **Input:** `Cell` (TON side)
@@ -153,5 +153,5 @@ The parser interprets the first bit of `100000` (which is `0`) as the presence f
 | **Address Format** | 36 Bytes (base64-decoded user-friendly: 1B flags + 1B workchain + 32B hash + 2B CRC) | 32 Bytes zero-padded (12B zeros + 20B address), length-prefixed by `CrossChainAddress` |
 | **Ordering** | `allowOutOfOrder = true` (Mandatory) | `allowOutOfOrder = true` (Recommended) |
 | **ExtraArgs Fmt** | ABI Encoded (`bytes`) | TL-B Encoded (`Cell`) |
-| **gasLimit units** | nanoTON (e.g. `100_000_000n` = 0.1 TON) | EVM gas units (e.g. `100_000`) |
+| **gasLimit units** | nanoGRAM (e.g. `100_000_000n` = 0.1 GRAM) | EVM gas units (e.g. `100_000`) |
 | **Data Format** | `bytes` → Wrapped in `Cell` | `Cell` → Unwrapped to `bytes` |

--- a/scripts/deploy/deployTONReceiver.ts
+++ b/scripts/deploy/deployTONReceiver.ts
@@ -52,7 +52,7 @@ async function main() {
   console.log('📤 Deploying from wallet:', walletFormats.bounceableNonTestable);
   console.log('Explorer:', walletExplorerLinks.bounceableNonTestableUrl);
   const balance = await walletContract.getBalance();
-  console.log('💰 Wallet balance:', fromNano(balance), 'TON\n');
+  console.log('💰 Wallet balance:', fromNano(balance), 'GRAM\n');
 
   // Compile contract
   console.log(`⏳ Compiling ${contractName}.tolk...`);

--- a/scripts/deploy/deployTONSender.ts
+++ b/scripts/deploy/deployTONSender.ts
@@ -31,7 +31,7 @@ async function main() {
   console.log('📤 Deploying from wallet:', walletFormats.bounceableNonTestable);
   console.log('Explorer:', walletExplorerLinks.bounceableNonTestableUrl)
   const balance = await walletContract.getBalance();
-  console.log('💰 Wallet balance:', fromNano(balance), 'TON\n');
+  console.log('💰 Wallet balance:', fromNano(balance), 'GRAM\n');
 
   // Compile contract
   console.log('⏳ Compiling MinimalSender.tolk...');

--- a/scripts/evm2ton/checkMessageOnTON.ts
+++ b/scripts/evm2ton/checkMessageOnTON.ts
@@ -138,7 +138,7 @@ async function verifyTONReceiver() {
     console.log('   Message ID:         ', messageId)
     console.log('   CCIP Explorer:      ', `${ccipExplorerUrl}/${messageId}`)
   }
-  console.log('   Value:              ', latest.value, 'TON')
+  console.log('   Value:              ', latest.value, 'GRAM')
   console.log('   Message:            ', foundMessage ? `"${foundMessage}"` : '(unable to decode)')
   console.log('   Time:               ', latest.time.toISOString())
   console.log('   TX Hash:            ', destinationTxHash)

--- a/scripts/evm2ton/sendMessage.ts
+++ b/scripts/evm2ton/sendMessage.ts
@@ -89,7 +89,7 @@ async function sendEVMToTON() {
   const messageData = ethers.toUtf8Bytes(argv.msg)
   const router = new ethers.Contract(sourceChain.router, IRouterClientArtifact.abi, wallet)
   const destChainSelector = BigInt(networkConfig.tonTestnet.chainSelector)
-  const message = buildCCIPMessageForTON(receiverBytes, messageData, 100_000_000n, true, selectedFeeToken) // 0.1 TON gas limit
+  const message = buildCCIPMessageForTON(receiverBytes, messageData, 100_000_000n, true, selectedFeeToken) // 0.1 GRAM gas limit
 
   const fee = await getCCIPFeeForTON(router, destChainSelector, message)
   // Add a 10% buffer 

--- a/scripts/ton2evm/sendMessage.ts
+++ b/scripts/ton2evm/sendMessage.ts
@@ -68,11 +68,11 @@ async function sendTONToEVM() {
 
   // Check balance
   const balance = await client.getBalance(wallet.address)
-  console.log('💰 Balance:', fromNano(balance), 'TON\n')
+  console.log('💰 Balance:', fromNano(balance), 'GRAM\n')
 
   if (balance < toNano('0.1')) {
-    console.error('❌ Insufficient balance. Need at least 0.1 TON')
-    console.log('Get testnet TON from @testgiver_ton_bot on Telegram')
+    console.error('❌ Insufficient balance. Need at least 0.1 GRAM')
+    console.log('Get testnet GRAM from @testgiver_ton_bot on Telegram')
     return
   }
 
@@ -107,11 +107,11 @@ async function sendTONToEVM() {
   // Add a 10% buffer
   const feeWithBuffer = (fee * 110n) / 100n
   // Fixed gas execution cost at the source (covers wallet-level gas and source execution)
-  const gasReserve = 500_000_000n // 0.5 TON
+  const gasReserve = 500_000_000n // 0.5 GRAM
 
-  console.log(`💸 Estimated CCIP fee: ${fee.toString()} nanoTON (${fromNano(fee)} TON)`)
-  console.log(`💸 Fee with 10% buffer: ${feeWithBuffer.toString()} nanoTON (${fromNano(feeWithBuffer)} TON)`)
-  console.log(`💸 Gas reserve: ${fromNano(gasReserve)} TON`)
+  console.log(`💸 Estimated CCIP fee: ${fee.toString()} nanoGRAM (${fromNano(fee)} GRAM)`)
+  console.log(`💸 Fee with 10% buffer: ${feeWithBuffer.toString()} nanoGRAM (${fromNano(feeWithBuffer)} GRAM)`)
+  console.log(`💸 Gas reserve: ${fromNano(gasReserve)} GRAM`)
 
   const ccipSendCell = buildCCIPMessageForEVM(
     ccipSendMessage.queryID, // seqno is used as queryID: unique per wallet, monotonically increasing, collision-free
@@ -128,13 +128,13 @@ async function sendTONToEVM() {
     const senderOverhead = toNano('0.1')
     const valueToAttach = feeWithBuffer + gasReserve
 
-    console.log(`💸 Value to attach to Router: ${fromNano(valueToAttach)} TON`)
-    console.log(`💸 Sender overhead: ${fromNano(senderOverhead)} TON`)
-    console.log(`💸 Total to send: ${fromNano(valueToAttach + senderOverhead)} TON`)
+    console.log(`💸 Value to attach to Router: ${fromNano(valueToAttach)} GRAM`)
+    console.log(`💸 Sender overhead: ${fromNano(senderOverhead)} GRAM`)
+    console.log(`💸 Total to send: ${fromNano(valueToAttach + senderOverhead)} GRAM`)
 
     if (balance < valueToAttach + senderOverhead) {
       console.error(
-        `❌ Insufficient balance. Required at least ${fromNano(valueToAttach + senderOverhead)} TON (fee + gas reserve + sender overhead), have ${fromNano(balance)} TON.`
+        `❌ Insufficient balance. Required at least ${fromNano(valueToAttach + senderOverhead)} GRAM (fee + gas reserve + sender overhead), have ${fromNano(balance)} GRAM.`
       )
       return
     }
@@ -162,7 +162,7 @@ async function sendTONToEVM() {
   } else {
     if (balance < feeWithBuffer + gasReserve) {
       console.error(
-        `❌ Insufficient balance for quoted fee. Required at least ${fromNano(feeWithBuffer + gasReserve)} TON (fee + gas reserve), have ${fromNano(balance)} TON.`
+        `❌ Insufficient balance for quoted fee. Required at least ${fromNano(feeWithBuffer + gasReserve)} GRAM (fee + gas reserve), have ${fromNano(balance)} GRAM.`
       )
       console.log('Try funding the wallet or lowering gas limit for cheaper execution.')
       return

--- a/scripts/utils/utils.ts
+++ b/scripts/utils/utils.ts
@@ -20,12 +20,12 @@ export function encodeEVMAddress(evmAddr: string): Buffer {
 
 /**
  * [EVM → TON] Encodes GenericExtraArgsV2 as ABI bytes for the EVM CCIP Router.
- * gasLimit is in nanoTON (e.g. 100_000_000n = 0.1 TON).
+ * gasLimit is in nanoGRAM (e.g. 100_000_000n = 0.1 GRAM).
  */
-export function buildExtraArgsForTON(gasLimitNanoTON: bigint | number, allowOutOfOrderExecution: boolean): Uint8Array {
+export function buildExtraArgsForTON(gasLimitNanoGRAM: bigint | number, allowOutOfOrderExecution: boolean): Uint8Array {
   const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
     ['uint256', 'bool'],
-    [gasLimitNanoTON, allowOutOfOrderExecution]
+    [gasLimitNanoGRAM, allowOutOfOrderExecution]
   )
   return ethers.getBytes(ethers.concat([GENERIC_EXTRA_ARGS_V2_TAG, encoded]))
 }
@@ -73,7 +73,7 @@ export function buildCCIPMessageForEVM(
 export function buildCCIPMessageForTON(
   receiver: Uint8Array,
   data: Uint8Array,
-  gasLimitNanoTON: bigint | number,
+  gasLimitNanoGRAM: bigint | number,
   allowOutOfOrderExecution: boolean,
   feeToken: string = ethers.ZeroAddress
 ) {
@@ -82,7 +82,7 @@ export function buildCCIPMessageForTON(
     data,
     tokenAmounts: [],
     feeToken,
-    extraArgs: buildExtraArgsForTON(gasLimitNanoTON, allowOutOfOrderExecution)
+    extraArgs: buildExtraArgsForTON(gasLimitNanoGRAM, allowOutOfOrderExecution)
   }
 }
 


### PR DESCRIPTION
## Summary
Renames native coin/currency references from TON/Toncoin/nanoTON to **GRAM** / **nanoGRAM** across the starter kit scripts, README, and example contracts.

API identifiers were updated where they denote the coin unit:
- `gasLimitNanoTON` → `gasLimitNanoGRAM` in `buildExtraArgsForTON` and `buildCCIPMessageForTON`
- Console output and docs now display GRAM / nanoGRAM for balances, fees, and gas reserves

## Out of scope
- **`chainlink-ton/` submodule** — left unchanged (protocol contracts and upstream naming)
- Chain/network references (TON Testnet, TON wallet, TON→EVM)
- Tolk stdlib calls (`ton()`, `fromNano()`, `toNano()`)
- Function names like `buildExtraArgsForTON` (EVM→TON direction)